### PR TITLE
Implement client validation

### DIFF
--- a/Facturation/UseCases/CreerFactureUseCase.swift
+++ b/Facturation/UseCases/CreerFactureUseCase.swift
@@ -9,7 +9,7 @@ struct CreerFactureUseCase {
     let repository: FactureRepository
 
     func execute(client: ClientModel, tva: Double = 20.0) throws -> FactureModel {
-        // guard client.isValid else { throw FactureError.invalidClient } // TODO: Add validation
+        guard client.isValidModel else { throw FactureError.invalidClient }
         guard tva >= 0 else { throw FactureError.invalidTVA }
         let numero = try repository.genererNumeroFacture(client: client)
         let facture = try repository.createFacture(client: client, numero: numero)

--- a/FacturationTests/UseCaseMappingTests.swift
+++ b/FacturationTests/UseCaseMappingTests.swift
@@ -24,6 +24,13 @@ final class UseCaseMappingTests: XCTestCase {
         XCTAssertEqual(facture.lignes.count, 0)
     }
 
+    @MainActor func testCreerFactureUseCase_InvalidClient() throws {
+        let client = Client()
+        XCTAssertThrowsError(try creerFacture.execute(client: client)) { error in
+            XCTAssertEqual(error as? FactureError, FactureError.invalidClient)
+        }
+    }
+
     @MainActor func testAjouterLigneUseCase() throws {
         let client = Client()
         let facture = try creerFacture.execute(client: client)


### PR DESCRIPTION
## Summary
- validate ClientModel when creating a facture
- expect invalidClient error in new unit test

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686ca338eb9c832f8f72a5725a959740