### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and Test
+        run: |
+          xcodebuild -project Facturation.xcodeproj -scheme Facturation -destination 'platform=macOS' test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for building and testing with macOS

## Testing
- `xcodebuild -project Facturation.xcodeproj -scheme Facturation -destination 'platform=macOS' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd3c169ac832fa2effc0105ae2ae4