### PR TITLE
Refactor invoice views to use DTOs

### DIFF
--- a/DataLayer/Sources/DataLayer/Services/DataService.swift
+++ b/DataLayer/Sources/DataLayer/Services/DataService.swift
@@ -1081,6 +1081,20 @@ extension DataService {
         }
     }
 
+    /// Récupère la facture DTO à partir de l'UUID.
+    func fetchFactureDTO(id: UUID) async -> FactureDTO? {
+        let descriptor = FetchDescriptor<FactureModel>(predicate: #Predicate { $0.id == id })
+        do {
+            if let facture = try modelContext.fetch(descriptor).first, facture.isValidModel {
+                return facture.toDTO()
+            }
+            return nil
+        } catch {
+            logger.error("Failed to fetch invoice", metadata: ["error": "\(error)"])
+            return nil
+        }
+    }
+
     /// Récupère le modèle Produit persistant à partir de l'UUID.
     func fetchProduitModel(id: UUID) async -> ProduitModel? {
         let descriptor = FetchDescriptor<ProduitModel>(predicate: #Predicate { $0.id == id })

--- a/Facturation/Views/Client/ClientDetailView.swift
+++ b/Facturation/Views/Client/ClientDetailView.swift
@@ -149,11 +149,11 @@ private struct FactureRowForClient: View {
     }
 }
 
-// MARK: - Wrapper pour charger le FactureModel avant de présenter la vue de détail.
+// MARK: - Wrapper pour charger le FactureDTO avant de présenter la vue de détail.
 private struct ClientFactureViewWrapper: View {
     let factureID: UUID
     @EnvironmentObject private var dataService: DataService
-    @State private var facture: FactureModel?
+    @State private var facture: FactureDTO?
     @State private var isLoading = true
 
     var body: some View {
@@ -166,11 +166,7 @@ private struct ClientFactureViewWrapper: View {
         if isLoading {
             ProgressView("Chargement de la facture...")
         } else if let facture = facture {
-            if facture.isValidModel {
-                ClientFactureDetailView(facture: facture)
-            } else {
-                invalidDataView
-            }
+            ClientFactureDetailView(facture: facture)
         } else {
             invalidDataView
         }
@@ -191,7 +187,7 @@ private struct ClientFactureViewWrapper: View {
     private func loadFactureModel() {
         Task {
             isLoading = true
-            self.facture = await dataService.fetchFactureModel(id: factureID)
+            self.facture = await dataService.fetchFactureDTO(id: factureID)
             isLoading = false
         }
     }

--- a/Facturation/Views/Client/ClientFactureDetailView.swift
+++ b/Facturation/Views/Client/ClientFactureDetailView.swift
@@ -7,9 +7,11 @@
 //
 
 import SwiftUI
+import DataLayer
 
 struct ClientFactureDetailView: View {
-    let facture: FactureModel
+    let facture: FactureDTO
+    @EnvironmentObject private var dataService: DataService
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -23,8 +25,8 @@ struct ClientFactureDetailView: View {
                 if let dateEcheance = facture.dateEcheance {
                     Text("Échéance : \(dateEcheance.formatted(date: .abbreviated, time: .omitted))")
                 }
-                Text("Montant total : \(facture.totalTTC.formatted(.currency(code: "EUR")))")
-                Text("Statut : \(facture.statut.description)")
+                Text("Montant total : \(facture.calculateTotalTTC(with: dataService.lignes).formatted(.currency(code: "EUR")))")
+                Text("Statut : \(facture.statutDisplay)")
             }
 
             Divider()
@@ -32,7 +34,7 @@ struct ClientFactureDetailView: View {
             Text("Lignes de facture")
                 .font(.headline)
 
-            List(facture.lignes) { ligne in
+            List(dataService.lignes.filter { facture.ligneIds.contains($0.id) }) { ligne in
                 VStack(alignment: .leading) {
                     Text(ligne.designation)
                         .font(.subheadline)


### PR DESCRIPTION
## Summary
- add `fetchFactureDTO` service helper
- refactor `ClientFactureViewModel` to fetch DTOs from `DataService`
- update `ClientFactureDetailView` to rely on DTO data
- simplify facture wrapper in `ClientDetailView`

## Testing
- `swift build` *(fails: package manifests cannot be accessed)*

------
https://chatgpt.com/codex/tasks/task_e_686cf1bc281c832faea7cb6e2697b3bb